### PR TITLE
Add `UUID` to `.env` and instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Tensor Market Boilerplate
+# Tensor Market Template
 
-**Welcome to the Tensor Marketplace Boilerplate!**
+**Welcome to the Tensor Marketplace Template!**
 
 This demo provides a simple foundation for building on the Tensor API, use it to get started building NOW!
 
@@ -31,7 +31,7 @@ npm install
 NEXT_PUBLIC_SOLANA_RPC_URL=               # Frontend Solana RPC
 SOLANA_RPC_URL=                           # Backend  Solana RPC
 TENSOR_API_KEY=                           
-NEXT_PUBLIC_COLLECTION_SLUG=              
+NEXT_PUBLIC_COLLECTION_SLUG_UUID=              
 ```
 
 #### Start the web app
@@ -43,4 +43,30 @@ npm run dev
 ### Important Folder / Files
  - `web/app/api` - Proxied requests to Tensor’s API
  - `web/app/page.tsx` - Index page, where data is fetched + rendered
+
+ ### How to get Collection Slug UUID
+Using the (Get Collections)[https://tensor.readme.io/reference/getcollections-1] Tensor API Endpoint, we're able to query for all collections with a given `slugsDisplay` or Human Readable Slug eg: `tensorians`.
+
+```JavaScript
+const options = {
+  method: "GET",
+  headers: {
+    accept: "application/json",
+    "x-tensor-api-key": TENSOR_API_KEY,
+  },
+};
+
+const url = "https://api.mainnet.tensordev.io/api/v1/collections";
+
+const queryParams = new URLSearchParams();
+queryParams.append("slugsDisplay", "tensorians");
+queryParams.append("sortBy", "statsV2.volume1h:desc");
+queryParams.append("limit", 1);
+
+const fullUrl = `${url}?${queryParams.toString()}`
+
+fetch(fullUrl)
+    .then(response => response.json())
+    .then(response => console.log(response.collections[0].slug))
+```
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
     axios
       .get('api/collectionListings', {
         params: {
-          collectionSlug: process.env.NEXT_PUBLIC_COLLECTION_SLUG!,
+          collectionSlug: process.env.NEXT_PUBLIC_COLLECTION_SLUG_UUID!,
           limit: mint ? 1 : 10,
           cursor,
           mint,
@@ -100,7 +100,7 @@ export default function Home() {
     axios
       .get('api/collectionStats', {
         params: {
-          collectionSlug: process.env.NEXT_PUBLIC_COLLECTION_SLUG!,
+          collectionSlug: process.env.NEXT_PUBLIC_COLLECTION_SLUG_UUID!,
         },
       })
       .then((response) => {


### PR DESCRIPTION
Integration partner Assetdash had issue working with the template and didn't understand/know the difference between our UUID and Human readable Collection slugs; the fixes here should address that confusion.

- Add `UUID` to env and associated variables 
- Add instructions to readme on how to get UUID slug from Human Readable Slug